### PR TITLE
fix #46: add example violating certificates

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -22,6 +22,10 @@
   <div id="outputbox">
   </div>
   <div id="timeseries"></div>
+  <table>
+    <thead><tr id="examplesHeader"></tr></thead>
+    <tbody><tr id="examplesBody"></tr></tbody>
+  </table>
   <script src="index.js" type="application/javascript;version=1.7"></script>
 </body>
 </html>

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -100,22 +100,33 @@ function clearExamples() {
   clearChildren("examplesBody");
 }
 
+let months = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov",
+  "Dec"
+];
+
 function makeExamples(examples) {
   let examplesHeader = document.getElementById("examplesHeader");
   let examplesBody = document.getElementById("examplesBody");
+  let exampleTypes = [];
   for (let key of Object.keys(examples)) {
-    if (!examples[key] || key == "issuer") {
-      continue;
+    if (key.endsWith("Example") && examples[key]) {
+      exampleTypes.push(key.substring(0, key.indexOf("Example")));
     }
+  }
+  for (let example of exampleTypes) {
     let header = document.createElement("th");
-    header.textContent = key;
+    let lastSeen = new Date(examples[example + "LastSeen"]);
+    header.textContent = example + " (last seen " + lastSeen.getDate() + " " +
+                         months[lastSeen.getMonth()] + " " +
+                         lastSeen.getFullYear() + ")";
     examplesHeader.appendChild(header);
     let td = document.createElement("td");
     let cert = document.createElement("textarea");
     cert.setAttribute("rows", 30);
     cert.setAttribute("cols", 66);
     cert.setAttribute("readonly", "");
-    cert.textContent = examples[key];
+    cert.textContent = examples[example + "Example"];
     td.appendChild(cert);
     examplesBody.appendChild(td);
   }

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -60,6 +60,7 @@ let commonLegend = {
 };
 
 function makeChart(name) {
+  clearExamples();
   let commonYAxis = [{ max: 1.0, min: 0.0 }, { min: 0, opposite: false }];
   if (name == "Worst CAs") {
     new Highcharts.StockChart({
@@ -76,13 +77,47 @@ function makeChart(name) {
     });
     document.getElementById("autocomplete").value = name;
   } else {
-    getChartData(name, function(series) {
+    getChartData(name, function(seriesAndExamples) {
       new Highcharts.StockChart({
         legend: commonLegend,
-        series: series,
+        series: seriesAndExamples.series,
         yAxis: commonYAxis
       });
+      makeExamples(seriesAndExamples.examples);
     });
+  }
+}
+
+function clearChildren(id) {
+  let element = document.getElementById(id);
+  while (element.children.length > 0) {
+    element.children[0].remove();
+  }
+}
+
+function clearExamples() {
+  clearChildren("examplesHeader");
+  clearChildren("examplesBody");
+}
+
+function makeExamples(examples) {
+  let examplesHeader = document.getElementById("examplesHeader");
+  let examplesBody = document.getElementById("examplesBody");
+  for (let key of Object.keys(examples)) {
+    if (!examples[key] || key == "issuer") {
+      continue;
+    }
+    let header = document.createElement("th");
+    header.textContent = key;
+    examplesHeader.appendChild(header);
+    let td = document.createElement("td");
+    let cert = document.createElement("textarea");
+    cert.setAttribute("rows", 30);
+    cert.setAttribute("cols", 66);
+    cert.setAttribute("readonly", "");
+    cert.textContent = examples[key];
+    td.appendChild(cert);
+    examplesBody.appendChild(td);
   }
 }
 

--- a/tools/sunlight.go
+++ b/tools/sunlight.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/x509"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"github.com/monicachew/certificatetransparency"
 	. "github.com/mozkeeler/sunlight"
 	"os"
+	"regexp"
 	"runtime"
 	"sync"
 	"time"
@@ -33,6 +35,16 @@ func init() {
 	flag.Uint64Var(&maxEntries, "max_entries", 0, "Max entries (0 means all)")
 	flag.StringVar(&rootCAFile, "rootCA_file", "rootCAList.txt", "list of root CA CNs")
 	runtime.GOMAXPROCS(runtime.NumCPU())
+}
+
+func certToString(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
+	b64 := base64.StdEncoding.EncodeToString(cert.Raw)
+	re := regexp.MustCompile(`(\S{64})`)
+	b64WithNewlines := re.ReplaceAllString(b64, "$1\r\n")
+	return "-----BEGIN CERTIFICATE-----\r\n" + b64WithNewlines + "\r\n-----END CERTIFICATE-----\r\n"
 }
 
 func main() {
@@ -87,7 +99,16 @@ func main() {
 		rawScore float,
 		normalizedCount integer,
 		rawCount integer,
-		beginTime bigint)
+		beginTime bigint);
+	drop table if exists examples;
+	create table examples(
+		issuer text,
+		validPeriodTooLongExample text,
+		deprecatedVersionExample text,
+		deprecatedSignatureAlgorithmExample text,
+		missingCNinSANExample text,
+		keyTooShortExample text,
+		expTooSmallExample text);
 	`
 
 	_, err = db.Exec(createTables)
@@ -143,6 +164,24 @@ func main() {
 	}
 	defer insertIssuerStatement.Close()
 
+	insertExample := `
+		insert into examples(
+			issuer,
+			validPeriodTooLongExample,
+			deprecatedVersionExample,
+			deprecatedSignatureAlgorithmExample,
+			missingCNinSANExample,
+			keyTooShortExample,
+			expTooSmallExample)
+		values(?, ?, ?, ?, ?, ?, ?)
+	`
+	insertExampleStatement, err := tx.Prepare(insertExample)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create prepared statement: %s\n", err)
+		os.Exit(1)
+	}
+	defer insertExampleStatement.Close()
+
 	fmt.Fprintf(os.Stderr, "Starting %s\n", time.Now())
 	in, err := os.Open(ctLog)
 	if err != nil {
@@ -169,6 +208,10 @@ func main() {
 
 	issuersLock := new(sync.Mutex)
 	issuers := make(map[string]*IssuerReputation)
+
+	exampleMapLock := new(sync.Mutex)
+	exampleMap := make(map[string]map[string]*x509.Certificate)
+
 	entriesFile.Map(func(ent *certificatetransparency.EntryAndPosition, err error) {
 		if err != nil {
 			return
@@ -263,6 +306,17 @@ func main() {
 				fmt.Fprintf(os.Stderr, "Couldn't write json: %s\n", err)
 				os.Exit(1)
 			}
+
+			exampleMapLock.Lock()
+			if exampleMap[cert.Issuer.CommonName] == nil {
+				exampleMap[cert.Issuer.CommonName] = make(map[string]*x509.Certificate)
+			}
+			for violation, isViolation := range summary.Violations {
+				if isViolation {
+					exampleMap[cert.Issuer.CommonName][violation] = cert
+				}
+			}
+			exampleMapLock.Unlock()
 		}
 	}, maxEntries)
 	fmt.Fprintf(out, "]}\n")
@@ -288,6 +342,20 @@ func main() {
 			issuer.NormalizedCount,
 			issuer.RawCount,
 			issuer.BeginTime)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to insert entry: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	for issuer, examples := range exampleMap {
+		_, err = insertExampleStatement.Exec(issuer,
+			certToString(examples[VALID_PERIOD_TOO_LONG]),
+			certToString(examples[DEPRECATED_VERSION]),
+			certToString(examples[DEPRECATED_SIGNATURE_ALGORITHM]),
+			certToString(examples[MISSING_CN_IN_SAN]),
+			certToString(examples[KEY_TOO_SHORT]),
+			certToString(examples[EXP_TOO_SMALL]))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to insert entry: %s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
For some reason I initially made this way more difficult than necessary, but I eventually arrived at a reasonable solution. For now the example certs are just PEM that you have to pipe through `openssl x509 -text -noout`, but I'm looking at some JS libraries that can parse certificates so we can expose the relevant information inline.