### PR TITLE
fix #60: display human-readable information from examples

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7,6 +7,23 @@
   <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.2/themes/smoothness/jquery-ui.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
   <script src="https://code.highcharts.com/stock/highstock.js"></script>
+
+  <script src="http://yui.yahooapis.com/2.9.0/build/yahoo/yahoo-min.js"></script>
+  <script src="jsrsasign/asn1-1.0.js"></script>
+  <script src="jsrsasign/ext/jsbn.js"></script>
+  <script src="jsrsasign/ext/jsbn2.js"></script>
+  <script src="jsrsasign/ext/rsa.js"></script>
+  <script src="jsrsasign/ext/rsa2.js"></script>
+  <script src="jsrsasign/ext/sha1.js"></script>
+  <script src="jsrsasign/ext/base64.js"></script>
+
+  <script src="jsrsasign/crypto-1.1.js"></script>
+  <script src="jsrsasign/asn1hex-1.1.js"></script>
+  <script src="jsrsasign/rsapem-1.1.js"></script>
+  <script src="jsrsasign/rsasign-1.2.js"></script>
+  <script src="jsrsasign/asn1x509-1.0.js"></script>
+  <script src="jsrsasign/x509-1.1.js"></script>
+
   <script src="series.js"></script>
 </head>
 <body>

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -7,23 +7,6 @@
   <link rel="stylesheet" href="https://code.jquery.com/ui/1.11.2/themes/smoothness/jquery-ui.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
   <script src="https://code.highcharts.com/stock/highstock.js"></script>
-
-  <script src="http://yui.yahooapis.com/2.9.0/build/yahoo/yahoo-min.js"></script>
-  <script src="jsrsasign/asn1-1.0.js"></script>
-  <script src="jsrsasign/ext/jsbn.js"></script>
-  <script src="jsrsasign/ext/jsbn2.js"></script>
-  <script src="jsrsasign/ext/rsa.js"></script>
-  <script src="jsrsasign/ext/rsa2.js"></script>
-  <script src="jsrsasign/ext/sha1.js"></script>
-  <script src="jsrsasign/ext/base64.js"></script>
-
-  <script src="jsrsasign/crypto-1.1.js"></script>
-  <script src="jsrsasign/asn1hex-1.1.js"></script>
-  <script src="jsrsasign/rsapem-1.1.js"></script>
-  <script src="jsrsasign/rsasign-1.2.js"></script>
-  <script src="jsrsasign/asn1x509-1.0.js"></script>
-  <script src="jsrsasign/x509-1.1.js"></script>
-
   <script src="series.js"></script>
 </head>
 <body>

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -127,26 +127,14 @@ function makeExamples(examples) {
                          lastSeen.getFullYear() + ")";
     examplesHeader.appendChild(header);
     let td = document.createElement("td");
-    let cert = new X509();
-    cert.readCertPEM(examples[example + "Example"]);
-    let signatureAlgorithm = KJUR.asn1.x509.OID.oid2name(
-      ASN1HEX.hextooidstr(cert.getSignatureAlgorithmOID().getValueHex()));
-    let items = [ ["version", cert.getVersion()],
-                  ["signature algorithm", signatureAlgorithm],
-                  ["valid from", certTimeToJSTime(cert.getNotBefore())],
-                  ["valid until", certTimeToJSTime(cert.getNotAfter())] ];
-    let table = createTable(items);
-    td.appendChild(table);
-
-    /*
-    let certPEMArea = document.createElement("textarea");
-    certPEMArea.setAttribute("rows", 30);
-    certPEMArea.setAttribute("cols", 66);
-    certPEMArea.setAttribute("readonly", "");
-    certPEMArea.textContent = examples[example + "Example"];
-    td.appendChild(certPEMArea);
-    */
-
+    let pem = examples[example + "Example"]
+                .replace(/[\r\n]/g, "")
+                .replace(/-----(BEGIN|END) CERTIFICATE-----/g, "");
+    let frame = document.createElement("iframe");
+    frame.width = "600px";
+    frame.height = "600px";
+    frame.src = "certsplainer/?" + pem;
+    td.appendChild(frame);
     examplesBody.appendChild(td);
   }
 }

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -139,32 +139,6 @@ function makeExamples(examples) {
   }
 }
 
-// XXX this is the DER formatting of time - look it up
-function certTimeToJSTime(certTime) {
-  let year = "20" + certTime.substring(0, 2); // yeah, fix this.
-  let month = certTime.substring(2, 4);
-  let day = certTime.substring(4, 6);
-  let hour = certTime.substring(6, 8);
-  let minute = certTime.substring(8, 10);
-  let second = certTime.substring(10, 12);
-  return new Date(year, month, day, hour, minute, second);
-}
-
-function createTable(items) {
-  let table = document.createElement("table");
-  for (let pair of items) {
-    let tr = document.createElement("tr");
-    let td1 = document.createElement("td");
-    td1.textContent = pair[0];
-    let td2 = document.createElement("td");
-    td2.textContent = pair[1];
-    tr.appendChild(td1);
-    tr.appendChild(td2);
-    table.appendChild(tr);
-  }
-  return table;
-}
-
 // Strangely, it looks like passing in values for legend and yAxis don't work,
 // so they have to be specified with each chart created.
 Highcharts.setOptions({


### PR DESCRIPTION
I made a separate repo at https://github.com/mozkeeler/certsplainer that has the generic certificate decoding utility page. It uses https://github.com/digitalbazaar/forge
This is live at https://people.mozilla.org/~dkeeler/dashboard/